### PR TITLE
Threadsafe TerminalLogger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.3'
+          - '1.6'
+          - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TerminalLoggers"
 uuid = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 authors = ["Chris Foster <chris42f@gmail.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 LeftChildRightSiblingTrees = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -397,7 +397,7 @@ end
         """
     end
 
-    if VERSION >= v"1.3.0"
+    @static if VERSION >= v"1.3.0"
         @testset "Parallel progress" begin
             buf = IOBuffer()
             io = IOContext(buf, :displaysize=>(30,75), :color=>false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@ using Test
 
 using Logging:
     LogLevel, BelowMinLevel, Debug, Info, Warn, Error, AboveMaxLevel,
-    shouldlog, handle_message, min_enabled_level, catch_exceptions
+    shouldlog, handle_message, min_enabled_level, catch_exceptions,
+    with_logger
 
 using ProgressLogging: Progress
 using UUIDs: UUID


### PR DESCRIPTION
Added a big lock around TerminalLogger state to make it safe to use
from multiple threads.

High-contention example to run interactively with `julia -t8`

```julia
using ProgressLogging
@sync begin
    for i=1:8
        Threads.@spawn @progress name="task $i" threshold=0.00005 for j=1:10000
            #sleep(0.001)
        end
    end
end
```

Fixes #18 

Also
* Bump version
* Fix tests which are now broken on julia 1.6 due to formatting detail
  of Matrix.
* Update CI to run on more recent Julia versions