### PR TITLE
Update dependency and fix deprecation

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,44 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TerminalLoggers"
 uuid = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 authors = ["Chris Foster <chris42f@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 LeftChildRightSiblingTrees = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
@@ -12,7 +12,7 @@ ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-LeftChildRightSiblingTrees = "0.1.1"
+LeftChildRightSiblingTrees = "0.1.1, 0.2"
 ProgressLogging = "0.1.1"
 julia = "1"
 

--- a/src/TerminalLogger.jl
+++ b/src/TerminalLogger.jl
@@ -169,12 +169,6 @@ function showvalue(io, key, e::Tuple{Exception,Any})
 end
 showvalue(io, key, ex::Exception) = showerror(io, ex)
 
-if VERSION >= v"1.7.0-DEV.1106"
-    @eval begin
-        showvalue(io, key, ex::Base.ExceptionStack) = Base.show_exception_stack(io, ex)
-    end
-end
-
 # Generate a text representation of all key value pairs, split into lines with
 # per-line indentation as an integer.
 function format_key_value_pairs(kwargs, io_context)

--- a/src/TerminalLogger.jl
+++ b/src/TerminalLogger.jl
@@ -151,9 +151,9 @@ end
 function showvalue(io, key, msg)
     if key === :exception && msg isa Vector && length(msg) > 1 && msg[1] isa Tuple{Exception,Any}
         if VERSION >= v"1.2"
-            # Ugly code path to support passing exception=Base.catch_stack() We
-            # don't have a useful "Exception Stack" type to look for here until
-            # https://github.com/JuliaLang/julia/pull/29901 gets unstuck.
+            # Ugly code path to support passing exception=Base.catch_stack()
+            # `Base.ExceptionStack` was only introduced in Julia 1.7.0-DEV.1106
+            # https://github.com/JuliaLang/julia/pull/29901 (dispatched on below).
             Base.show_exception_stack(io, msg)
         else
             # v1.0 and 1.1 don't have Base.show_exception_stack
@@ -168,6 +168,12 @@ function showvalue(io, key, e::Tuple{Exception,Any})
     showerror(io, ex, bt; backtrace = bt!==nothing)
 end
 showvalue(io, key, ex::Exception) = showerror(io, ex)
+
+if VERSION >= v"1.7.0-DEV.1106"
+    @eval begin
+        showvalue(io, key, ex::Base.ExceptionStack) = Base.show_exception_stack(io, ex)
+    end
+end
 
 # Generate a text representation of all key value pairs, split into lines with
 # per-line indentation as an integer.

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -205,7 +205,11 @@ end
             try
                 error("An exception")
             catch
-                Base.catch_stack()
+                if VERSION >= v"1.7.0-DEV.1106"
+                    current_exceptions()
+                else
+                    Base.catch_stack()
+                end
             end
         end
         @test occursin(r"An exception.*Stacktrace.*caused by.*Root cause.*Stacktrace"s,


### PR DESCRIPTION
I just noticed that TerminalLoggers holds back LeftChildRightSiblingTrees. This PR bumps the dependency and adds a CompatHelper setup to automate such updates in the future.

Moreover, when running the tests a deprecation warning turned up which I fixed. While doing that I came across https://github.com/JuliaLang/julia/pull/29901 and adapted the package accordingly.